### PR TITLE
Updated obsolete PHP namespace seperator from "::" to "\"

### DIFF
--- a/src/main/php/xml/Node.class.php
+++ b/src/main/php/xml/Node.class.php
@@ -98,7 +98,7 @@ class Node extends \lang\Object {
     if (null !== $name) return self::fromArray($vars, $name);
 
     $class= get_class($obj);
-    return self::fromArray($vars, (false !== ($p= strrpos($class, '::'))) ? substr($class, $p+ 2): $class);
+    return self::fromArray($vars, (false !== ($p= strrpos($class, '\\'))) ? substr($class, $p+ 2): $class);
   }
 
   /**

--- a/src/main/php/xml/Node.class.php
+++ b/src/main/php/xml/Node.class.php
@@ -97,8 +97,8 @@ class Node extends \lang\Object {
 
     if (null !== $name) return self::fromArray($vars, $name);
 
-    $class= get_class($obj);
-    return self::fromArray($vars, (false !== ($p= strrpos($class, '\\'))) ? substr($class, $p+ 2): $class);
+    $class= utf8_encode(get_class($obj));
+    return self::fromArray($vars, (false !== ($p= strrpos($class, '\\'))) ? substr($class, $p+ 1): $class);
   }
 
   /**

--- a/src/main/php/xml/Node.class.php
+++ b/src/main/php/xml/Node.class.php
@@ -97,7 +97,7 @@ class Node extends \lang\Object {
 
     if (null !== $name) return self::fromArray($vars, $name);
 
-    $class= utf8_encode(get_class($obj));
+    $class= get_class($obj);
     return self::fromArray($vars, (false !== ($p= strrpos($class, '\\'))) ? substr($class, $p+ 1): $class);
   }
 

--- a/src/test/php/xml/unittest/NodeTest.class.php
+++ b/src/test/php/xml/unittest/NodeTest.class.php
@@ -197,16 +197,11 @@ class NodeTest extends \unittest\TestCase {
 
   #[@test]
   public function fromObjectShortName() {
-
-    $obj= new Object([
-        '__construct' => function() {}
-      ]);
-
     $this->assertEquals(
       "<Object>\n".
       "  <__id/>\n".
       "</Object>",
-      $this->sourceOf(Node::fromObject($obj, null))
+      $this->sourceOf(Node::fromObject(new Object(), null))
     );
   }
 }

--- a/src/test/php/xml/unittest/NodeTest.class.php
+++ b/src/test/php/xml/unittest/NodeTest.class.php
@@ -184,7 +184,7 @@ class NodeTest extends \unittest\TestCase {
       "  <name>Name goes here</name>\n".
       "  <__id/>\n".
       "</node>",
-      $this->sourceOf(Node::fromObject(newinstance(Object::class, [], [
+      $this->sourceOf(Node::fromObject(newinstance('lang\Object', [], [
         'id'          => 1549,
         'color'       => 'green',
         'name'        => null,

--- a/src/test/php/xml/unittest/NodeTest.class.php
+++ b/src/test/php/xml/unittest/NodeTest.class.php
@@ -184,7 +184,7 @@ class NodeTest extends \unittest\TestCase {
       "  <name>Name goes here</name>\n".
       "  <__id/>\n".
       "</node>",
-      $this->sourceOf(Node::fromObject(newinstance('lang.Object', [], [
+      $this->sourceOf(Node::fromObject(newinstance(Object::class, [], [
         'id'          => 1549,
         'color'       => 'green',
         'name'        => null,

--- a/src/test/php/xml/unittest/NodeTest.class.php
+++ b/src/test/php/xml/unittest/NodeTest.class.php
@@ -194,4 +194,24 @@ class NodeTest extends \unittest\TestCase {
       ]), 'node'))
     );
   }
+
+  #[@test]
+  public function fromObjectShortName() {
+    $this->assertEquals(
+      "<Object·6>\n".
+      "  <id>1549</id>\n".
+      "  <color>green</color>\n".
+      "  <name>Name goes here</name>\n".
+      "  <__id/>\n".
+      "</Object·6>",
+      $this->sourceOf(Node::fromObject(newinstance('lang\Object', [], [
+        'id'          => 1549,
+        'color'       => 'green',
+        'name'        => null,
+        '__construct' => function() {
+          $this->name= 'Name goes here';
+        }
+      ]), null))
+    );
+  }
 }

--- a/src/test/php/xml/unittest/NodeTest.class.php
+++ b/src/test/php/xml/unittest/NodeTest.class.php
@@ -184,7 +184,7 @@ class NodeTest extends \unittest\TestCase {
       "  <name>Name goes here</name>\n".
       "  <__id/>\n".
       "</node>",
-      $this->sourceOf(Node::fromObject(newinstance('lang\Object', [], [
+      $this->sourceOf(Node::fromObject(newinstance('lang.Object', [], [
         'id'          => 1549,
         'color'       => 'green',
         'name'        => null,
@@ -197,21 +197,16 @@ class NodeTest extends \unittest\TestCase {
 
   #[@test]
   public function fromObjectShortName() {
+
+    $obj= new Object([
+        '__construct' => function() {}
+      ]);
+
     $this->assertEquals(
-      "<Object·6>\n".
-      "  <id>1549</id>\n".
-      "  <color>green</color>\n".
-      "  <name>Name goes here</name>\n".
+      "<Object>\n".
       "  <__id/>\n".
-      "</Object·6>",
-      $this->sourceOf(Node::fromObject(newinstance('lang\Object', [], [
-        'id'          => 1549,
-        'color'       => 'green',
-        'name'        => null,
-        '__construct' => function() {
-          $this->name= 'Name goes here';
-        }
-      ]), null))
+      "</Object>",
+      $this->sourceOf(Node::fromObject($obj, null))
     );
   }
 }


### PR DESCRIPTION
@kiesel told me to create this merge request to prevent XML errors, while using PHP namespaces as Node name.
With the current "::" the short name won't be build.
