### PR TITLE
XP9 Compat

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,12 @@ XML APIs for the XP Framework ChangeLog
 
 ## ?.?.? / ????-??-??
 
+## 9.0.0 / 2017-05-29
+
+* Merged PR #3: XP9 Compat. **Heads up:** xml.Tree, xml.Node, xml.CData and
+  xml.PCData now implement `lang.Value` instead of extending `lang.Object`.
+  (@thekid)
+
 ## 8.0.2 / 2017-05-20
 
 * Refactored code to use `typeof()` instead of `xp::typeOf()`, see

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "XML APIs for the XP Framework",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^8.0 | ^7.0 | ^6.5",
+    "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.5",
     "xp-framework/collections": "^8.0 | ^7.0 | ^6.5",
     "php" : ">=5.6.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^8.0 | ^7.0 | ^6.5",
-    "xp-framework/collections": "^7.0 | ^6.5",
+    "xp-framework/collections": "^8.0 | ^7.0 | ^6.5",
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^7.0 | ^6.5"
+    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/main/php/xml/CData.class.php
+++ b/src/main/php/xml/CData.class.php
@@ -18,7 +18,7 @@
  *
  * @purpose  Wrapper
  */
-class CData extends \lang\Object {
+class CData {
   public $cdata= '';
     
   /**

--- a/src/main/php/xml/CData.class.php
+++ b/src/main/php/xml/CData.class.php
@@ -15,10 +15,8 @@
  *     <data><![CDATA[<Hello World>]]></data>
  *   </document>
  * </pre>
- *
- * @purpose  Wrapper
  */
-class CData {
+class CData implements \lang\Value {
   public $cdata= '';
     
   /**
@@ -37,5 +35,20 @@ class CData {
    */
   public function toString() {
     return nameof($this).'('.$this->cdata.')';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'C'.md5($this->cdata);
+  }
+
+  /**
+   * Compare this tree to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->cdata, $value->cdata) : 1;
   }
 }

--- a/src/main/php/xml/DomXSLProcessor.class.php
+++ b/src/main/php/xml/DomXSLProcessor.class.php
@@ -27,7 +27,7 @@ use xml\xslt\XSLStringCallback;
  * @ext      xslt
  * @test     xp://xml.unittest.DomXslProcessorTest
  */
-class DomXSLProcessor extends \lang\Object implements IXSLProcessor {
+class DomXSLProcessor implements IXSLProcessor {
   public 
     $processor      = null,
     $stylesheet     = null,

--- a/src/main/php/xml/Node.class.php
+++ b/src/main/php/xml/Node.class.php
@@ -1,5 +1,8 @@
 <?php namespace xml;
 
+use lang\Value;
+use util\Objects;
+
 define('INDENT_DEFAULT',    0);
 define('INDENT_WRAPPED',    1);
 define('INDENT_NONE',       2);
@@ -12,9 +15,8 @@ define('XML_ILLEGAL_CHARS',   "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e\
  * @see   xp://xml.Tree#addChild
  * @test  xp://xml.unittest.NodeTest
  */
-class Node {
-  const
-    XML_ILLEGAL_CHARS   = XML_ILLEGAL_CHARS;
+class Node implements Value {
+  const XML_ILLEGAL_CHARS   = XML_ILLEGAL_CHARS;
 
   public 
     $name         = '',
@@ -25,11 +27,11 @@ class Node {
   /**
    * Constructor
    *
-   * <code>
-   *   $n= new Node('document');
-   *   $n= new Node('text', 'Hello World');
-   *   $n= new Node('article', '', array('id' => 42));
-   * </code>
+   * ```php
+   * $n= new Node('document');
+   * $n= new Node('text', 'Hello World');
+   * $n= new Node('article', '', ['id' => 42]);
+   * ```
    *
    * @param   string name
    * @param   string content default NULL
@@ -399,35 +401,42 @@ class Node {
     return $this->children[$pos];
   }
   
-  /**
-   * Returns whether another object is equal to this node
-   *
-   * @param   lang.Generic cmp
-   * @return  bool
-   */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->toString() === $cmp->toString();
-  }
-
-  /**
-   * Creates a string representation of this object
-   *
-   * @return  string
-   */
+  /** @return string */
   public function toString() {
     $a= '';
     foreach ($this->attribute as $name => $value) {
       $a.= ' @'.$name.'= '.\xp::stringOf($value);
     }
     $s= nameof($this).'('.$this->name.$a.') {';
-    if (!$this->children) {
-      $s.= null === $this->content ? ' ' : ' '.\xp::stringOf($this->content).' ';
-    } else {
+    if ($this->children) {
       $s.= null === $this->content ? "\n" : "\n  ".\xp::stringOf($this->content)."\n";
       foreach ($this->children as $child) {
-        $s.= '  '.\xp::stringOf($child, '  ')."\n";
+        $s.= '  '.str_replace("\n", "\n  ", $child->toString())."\n";
       }
+    } else {
+      $s.= null === $this->content ? ' ' : ' '.\xp::stringOf($this->content).' ';
     }
     return $s.'}';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return md5($this->name.$this->content.Objects::hashOf($this->attribute).Objects::hashOf($this->children));
+  }
+
+  /**
+   * Compare this tree to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare(
+        [$this->name, $this->content, $this->attribute, $this->children],
+        [$value->name, $value->content, $value->attribute, $this->children]
+      )
+      : 1
+    ;
   }
 }

--- a/src/main/php/xml/Node.class.php
+++ b/src/main/php/xml/Node.class.php
@@ -12,7 +12,7 @@ define('XML_ILLEGAL_CHARS',   "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e\
  * @see   xp://xml.Tree#addChild
  * @test  xp://xml.unittest.NodeTest
  */
-class Node extends \lang\Object {
+class Node {
   const
     XML_ILLEGAL_CHARS   = XML_ILLEGAL_CHARS;
 

--- a/src/main/php/xml/PCData.class.php
+++ b/src/main/php/xml/PCData.class.php
@@ -19,10 +19,8 @@
  * Note: The XML passed to PCDatas constructor is not validated!
  * Passing incorrect XML to this class will result in a not-
  * wellformed output document.
- *
- * @purpose  Wrapper
  */
-class PCData {
+class PCData implements \lang\Value {
   public $pcdata= '';
     
   /**
@@ -41,5 +39,20 @@ class PCData {
    */
   public function toString() {
     return nameof($this).'('.$this->pcdata.')';
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'C'.md5($this->pcdata);
+  }
+
+  /**
+   * Compare this tree to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->pcdata, $value->pcdata) : 1;
   }
 }

--- a/src/main/php/xml/PCData.class.php
+++ b/src/main/php/xml/PCData.class.php
@@ -22,7 +22,7 @@
  *
  * @purpose  Wrapper
  */
-class PCData extends \lang\Object {
+class PCData {
   public $pcdata= '';
     
   /**

--- a/src/main/php/xml/QName.class.php
+++ b/src/main/php/xml/QName.class.php
@@ -15,7 +15,7 @@
  *
  * @purpose  XML Namespaces
  */
-class QName extends \lang\Object {
+class QName {
   public
     $namespace    = '',
     $localpart    = '',

--- a/src/main/php/xml/Tree.class.php
+++ b/src/main/php/xml/Tree.class.php
@@ -1,6 +1,8 @@
 <?php namespace xml;
  
 use io\FileUtil;
+use lang\Value;
+use util\Objects;
 use xml\parser\ParserCallback;
 use xml\parser\XMLParser;
 
@@ -11,7 +13,7 @@ use xml\parser\XMLParser;
  * @test  xp://unittest.xml.TreeTest
  * @see   xp://xml.parser.XMLParser
  */
-class Tree implements ParserCallback {
+class Tree implements ParserCallback, Value {
   public 
     $root     = null,
     $nodeType = null;
@@ -265,18 +267,35 @@ class Tree implements ParserCallback {
     unset($this->_cnt, $this->_cdata, $this->_objs);
   }
 
-  /**
-   * Creates a string representation of this object
-   *
-   * @return  string
-   */
+  /** @return string */
   public function toString() {
     return sprintf(
       "%s(version=%s encoding=%s)@{\n  %s\n}",
       nameof($this),
       $this->version,
       $this->encoding,
-      \xp::stringOf($this->root, '  ')
+      str_replace("\n", "\n  ", $this->root->toString())
     );
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return md5($this->version.$this->encoding.$this->root->hashCode());
+  }
+
+  /**
+   * Compare this tree to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare(
+        [$this->version, $this->encoding, $this->root],
+        [$value->version, $value->encoding, $value->root]
+      )
+      : 1
+    ;
   }
 } 

--- a/src/main/php/xml/Tree.class.php
+++ b/src/main/php/xml/Tree.class.php
@@ -11,7 +11,7 @@ use xml\parser\XMLParser;
  * @test  xp://unittest.xml.TreeTest
  * @see   xp://xml.parser.XMLParser
  */
-class Tree extends \lang\Object implements ParserCallback {
+class Tree implements ParserCallback {
   public 
     $root     = null,
     $nodeType = null;

--- a/src/main/php/xml/XPath.class.php
+++ b/src/main/php/xml/XPath.class.php
@@ -23,7 +23,7 @@ use lang\IllegalArgumentException;
  * @test     xp://xml.unittest.XPathTest
  * @purpose  Provide XPath functionality
  */
-class XPath extends \lang\Object {
+class XPath {
   public $context= null;
 
   static function __static() {

--- a/src/main/php/xml/XSLCallback.class.php
+++ b/src/main/php/xml/XSLCallback.class.php
@@ -9,7 +9,7 @@ use lang\ElementNotFoundException;
  * @test  xp://xml.unittest.XslCallbackTest
  * @see   php://xslt_registerphpfunctions
  */
-class XSLCallback extends \lang\Object {
+class XSLCallback {
   private $instances= [];
   private static $instance;
     
@@ -60,7 +60,7 @@ class XSLCallback extends \lang\Object {
     );
 
     $instance= self::$instance->instances[$name];
-    if (!($instance->getClass()->getMethod($method)->hasAnnotation('xslmethod'))) {
+    if (!(typeof($instance)->getMethod($method)->hasAnnotation('xslmethod'))) {
       throw new ElementNotFoundException('Instance "'.$name.'" does not have method "'.$method.'"');
     }
 

--- a/src/main/php/xml/io/XmlWriter.class.php
+++ b/src/main/php/xml/io/XmlWriter.class.php
@@ -6,7 +6,7 @@
  * Outputs XML.
  *
  */
-abstract class XmlWriter extends \lang\Object {
+abstract class XmlWriter {
 
   /**
    * Start writing a document

--- a/src/main/php/xml/meta/Marshaller.class.php
+++ b/src/main/php/xml/meta/Marshaller.class.php
@@ -18,7 +18,7 @@ use xml\XMLFormatException;
  * @ext   dom
  * @see   http://castor.org/xml-mapping.html
  */
-class Marshaller extends \lang\Object {
+class Marshaller {
 
   /**
    * Iterate over class methods with @xmlfactory annotation
@@ -110,14 +110,14 @@ class Marshaller extends \lang\Object {
         }
       } else if ($result instanceof \Traversable) {
         foreach ($result as $value) {
-          if ($value instanceof \lang\Generic) {
-            self::recurse($value, $value->getClass(), $node->addChild(new \xml\Node($element)), $inject);
+          if (is_object($value)) {
+            self::recurse($value, typeof($value), $node->addChild(new \xml\Node($element)), $inject);
           } else {
             $node->addChild(new \xml\Node($element, $value));
           }
         }
-      } else if ($result instanceof \lang\Generic) {
-        self::recurse($result, $result->getClass(), $node->addChild(new \xml\Node($element)), $inject);
+      } else if (is_object($result)) {
+        self::recurse($result, typeof($result), $node->addChild(new \xml\Node($element)), $inject);
       }
     }
   }
@@ -131,7 +131,7 @@ class Marshaller extends \lang\Object {
    * @deprecated  Use marshalTo() instead
    */
   public static function marshal($instance, $qname= null) {
-    $class= $instance->getClass();
+    $class= typeof($instance);
 
     // Create XML tree and root node. Use the information provided by the
     // qname argument if existant, use the class` non-qualified (and 
@@ -155,12 +155,12 @@ class Marshaller extends \lang\Object {
    * Marshal an object to xml
    *
    * @param   xml.Node target
-   * @param   lang.Object instance
+   * @param   object $instance
    * @param   [:var] inject
    * @return  xml.Node the given target
    */
-  public function marshalTo(\xml\Node $target= null, \lang\Generic $instance, $inject= []) {
-    $class= $instance->getClass();
+  public function marshalTo(\xml\Node $target= null, $instance, $inject= []) {
+    $class= typeof($instance);
 
     // Create node if not existant
     if (null === $target) $target= new \xml\Node(null);

--- a/src/main/php/xml/meta/Unmarshaller.class.php
+++ b/src/main/php/xml/meta/Unmarshaller.class.php
@@ -19,7 +19,7 @@ use io\streams\Streams;
  * @ext   dom
  * @see   http://castor.org/xml-mapping.html
  */
-class Unmarshaller extends \lang\Object {
+class Unmarshaller {
 
   static function __static() {
     libxml_use_internal_errors(true);

--- a/src/main/php/xml/parser/FileInputSource.class.php
+++ b/src/main/php/xml/parser/FileInputSource.class.php
@@ -9,7 +9,7 @@ use io\streams\FileInputStream;
  *
  * @see      xp://xml.parser.XMLParser#parse
  */
-class FileInputSource extends \lang\Object implements InputSource {
+class FileInputSource implements InputSource {
   protected
     $file   = null,
     $stream = null;

--- a/src/main/php/xml/parser/StreamInputSource.class.php
+++ b/src/main/php/xml/parser/StreamInputSource.class.php
@@ -7,7 +7,7 @@
  *
  * @see      xp://xml.parser.XMLParser#parse
  */
-class StreamInputSource extends \lang\Object implements InputSource {
+class StreamInputSource implements InputSource {
   protected
     $stream = null,
     $source = '';

--- a/src/main/php/xml/parser/StringInputSource.class.php
+++ b/src/main/php/xml/parser/StringInputSource.class.php
@@ -8,7 +8,7 @@ use io\streams\MemoryInputStream;
  *
  * @see      xp://xml.parser.XMLParser#parse
  */
-class StringInputSource extends \lang\Object implements InputSource {
+class StringInputSource implements InputSource {
   protected
     $stream = null,
     $source = '';

--- a/src/main/php/xml/parser/TreeInputSource.class.php
+++ b/src/main/php/xml/parser/TreeInputSource.class.php
@@ -9,7 +9,7 @@ use xml\Tree;
  *
  * @see      xp://xml.parser.XMLParser#parse
  */
-class TreeInputSource extends \lang\Object implements InputSource {
+class TreeInputSource implements InputSource {
   protected
     $stream = null,
     $source = '';

--- a/src/main/php/xml/parser/XMLParser.class.php
+++ b/src/main/php/xml/parser/XMLParser.class.php
@@ -23,7 +23,7 @@ use xml\XMLFormatException;
  * @test    xp://xml.unittest.StreamXMLParserTest
  * @test    xp://xml.unittest.StringXMLParserTest
  */
-class XMLParser extends \lang\Object {
+class XMLParser {
   public
     $encoding     = '',
     $callback     = null;

--- a/src/main/php/xml/xslt/XSLDateCallback.class.php
+++ b/src/main/php/xml/xslt/XSLDateCallback.class.php
@@ -16,7 +16,7 @@ use lang\XPClass;
  * @test      xp://xml.unittest.XslCallbackTest
  * @purpose   XSL callback
  */
-class XSLDateCallback extends \lang\Object {
+class XSLDateCallback {
 
   /**
    * Format the given date with the format specifier

--- a/src/main/php/xml/xslt/XSLStringCallback.class.php
+++ b/src/main/php/xml/xslt/XSLStringCallback.class.php
@@ -6,7 +6,7 @@
  * @purpose   XSL callback
  * @test      xp://xml.unittest.XslCallbackTest
  */
-class XSLStringCallback extends \lang\Object {
+class XSLStringCallback {
 
   /**
    * urlencode() string

--- a/src/test/php/xml/unittest/AbstractProcessorTest.class.php
+++ b/src/test/php/xml/unittest/AbstractProcessorTest.class.php
@@ -36,7 +36,7 @@ abstract class AbstractProcessorTest extends \unittest\TestCase {
    * @return  string
    */
   protected function includeUri($stylesheet) {
-    $name= $this->getClass()->getPackage()->getResourceAsStream($stylesheet.'.xsl')->getURI();
+    $name= typeof($this)->getPackage()->getResourceAsStream($stylesheet.'.xsl')->getURI();
     
     // Normalize URI according to http://en.wikipedia.org/wiki/File_URI_scheme
     // * "f:\a dir\c.xsl"       => "file:///f:/a%20dor/c.xsl"

--- a/src/test/php/xml/unittest/ApplicationType.class.php
+++ b/src/test/php/xml/unittest/ApplicationType.class.php
@@ -7,6 +7,6 @@
  * @see  xp://xml.unittest.MarshallerTest
  */
 #[@xmlns(app = 'http://projects.xp-framework.net/xmlns/app')]
-class ApplicationType extends \lang\Object {
+class ApplicationType {
 
 }

--- a/src/test/php/xml/unittest/ButtonType.class.php
+++ b/src/test/php/xml/unittest/ButtonType.class.php
@@ -6,7 +6,7 @@
  *
  * @see  xp://xml.unittest.DialogType
  */
-class ButtonType extends \lang\Object {
+class ButtonType {
   public $id= '';
   public $caption= '';
 

--- a/src/test/php/xml/unittest/DialogType.class.php
+++ b/src/test/php/xml/unittest/DialogType.class.php
@@ -7,7 +7,7 @@
  * @see  xp://xml.unittest.MarshallerTest
  * @see  rfc://0040
  */
-class DialogType extends \lang\Object {
+class DialogType {
   public
     $id       = '',
     $caption  = '',

--- a/src/test/php/xml/unittest/IdBasedTypeFactory.class.php
+++ b/src/test/php/xml/unittest/IdBasedTypeFactory.class.php
@@ -4,7 +4,7 @@
  * Type factory
  */
 #[@xmlmapping(factory= 'forName', pass= ['@id'])]
-class IdBasedTypeFactory extends \lang\Object {
+class IdBasedTypeFactory {
   
   /**
    * Factory method

--- a/src/test/php/xml/unittest/NameBasedTypeFactory.class.php
+++ b/src/test/php/xml/unittest/NameBasedTypeFactory.class.php
@@ -4,7 +4,7 @@
  * Type factory
  */
 #[@xmlmapping(factory= 'forName')]
-class NameBasedTypeFactory extends \lang\Object {
+class NameBasedTypeFactory {
   
   /**
    * Factory method

--- a/src/test/php/xml/unittest/NodeTest.class.php
+++ b/src/test/php/xml/unittest/NodeTest.class.php
@@ -204,4 +204,38 @@ class NodeTest extends \unittest\TestCase {
       $this->sourceOf(Node::fromObject(new Object(), null))
     );
   }
+
+  #[@test]
+  public function as_string() {
+    $this->assertEquals(
+      'xml.Node(doc) { }',
+      (new Node('doc'))->toString()
+    );
+  }
+
+  #[@test]
+  public function as_string_with_content() {
+    $this->assertEquals(
+      'xml.Node(test) { "Succeeded" }',
+      (new Node('test', 'Succeeded'))->toString()
+    );
+  }
+
+  #[@test]
+  public function as_string_with_attributes() {
+    $this->assertEquals(
+      'xml.Node(a @href= "http://example.com") { }',
+      (new Node('a', null, ['href' => 'http://example.com']))->toString()
+    );
+  }
+
+  #[@test]
+  public function as_string_with_children() {
+    $this->assertEquals(
+      "xml.Node(div) {\n".
+      "  xml.Node(p) { \"Test\" }\n".
+      "}",
+      (new Node('div'))->withChild(new Node('p', 'Test'))->toString()
+    );
+  }
 }

--- a/src/test/php/xml/unittest/ScrollBarType.class.php
+++ b/src/test/php/xml/unittest/ScrollBarType.class.php
@@ -7,6 +7,6 @@
  * @see  rfc://0040
  */
 #[@xmlfactory(element = 'scroll')]
-class ScrollBarType extends \lang\Object {
+class ScrollBarType {
 
 }

--- a/src/test/php/xml/unittest/TextInputType.class.php
+++ b/src/test/php/xml/unittest/TextInputType.class.php
@@ -6,7 +6,7 @@
  * @see  xp://xml.unittest.UnmarshallerTest
  * @see  xp://xml.unittest.MarshallerTest
  */
-class TextInputType extends \lang\Object {
+class TextInputType {
   protected $id= '';
   protected $disabled= false;
 

--- a/src/test/php/xml/unittest/TreeTest.class.php
+++ b/src/test/php/xml/unittest/TreeTest.class.php
@@ -169,4 +169,14 @@ class TreeTest extends \unittest\TestCase {
     $this->assertEquals('document', $tree->root()->getName());
     $this->assertEquals('Some umlauts: öäü', $tree->root()->nodeAt(0)->getContent());
   }
+
+  #[@test]
+  public function as_string() {
+    $this->assertEquals(
+      "xml.Tree(version=1.0 encoding=utf-8)@{\n".
+      "  xml.Node(doc) { }\n".
+      "}",
+      (new Tree('doc'))->toString()
+    );
+  }
 }

--- a/src/test/php/xml/unittest/WindowType.class.php
+++ b/src/test/php/xml/unittest/WindowType.class.php
@@ -6,7 +6,7 @@
  * @see  xp://xml.unittest.UnmarshallerTest
  * @see  xp://xml.unittest.MarshallerTest
  */
-class WindowType extends \lang\Object {
+class WindowType {
   protected $window= null;
 
   /**


### PR DESCRIPTION
This pull request makes the unittest library compatible with XP9:

* Removes `lang.Object` references, replacing them with dedicated value objects
* Implements `lang.Value` where toString() / hashCode() / comparison are necessary
* Rewrites `$instance->getClass()` to `typeof()`.