### PR TITLE
Remove deprecated static Marshaller / Unmarshaller usage

### DIFF
--- a/src/main/php/xml/meta/Marshaller.class.php
+++ b/src/main/php/xml/meta/Marshaller.class.php
@@ -7,15 +7,8 @@ use xml\{QName, Tree, Node, XMLFormatException, Xmlfactory, Xmlns};
 /**
  * Marshalls XML from objects by using annotations.
  *
- * Example:
- * ```php
- * // [...create transmission object...]
- *
- * $xml= Marshaller::marshal($transmission);
- * ```
- *
- * @test  xml.unittest.MarshallerTest
  * @ext   dom
+ * @test  xml.unittest.MarshallerTest
  * @see   http://castor.org/xml-mapping.html
  */
 class Marshaller {
@@ -121,35 +114,6 @@ class Marshaller {
     }
   }
 
-  /**
-   * Marshal an object to xml
-   *
-   * @param   object instance
-   * @param   xml.QName qname default NULL
-   * @return  string xml
-   * @deprecated  Use marshalTo() instead
-   */
-  public static function marshal($instance, $qname= null) {
-    $type= Reflection::type($instance);
-
-    // Create XML tree and root node. Use the information provided by the
-    // qname argument if existant, use the class` non-qualified (and 
-    // lowercased) name otherwise.
-    $tree= new Tree();
-    if ($qname) {
-      $prefix= $qname->prefix ? $qname->prefix : $qname->localpart[0];
-      $tree->root()->setName($prefix.':'.$qname->localpart);
-      $tree->root()->setAttribute('xmlns:'.$prefix, $qname->namespace);
-    } else if ($type->annotation(Xmlns::class)) {
-      $tree->root()->setName($type->class()->getSimpleName());
-    } else {
-      $tree->root()->setName(strtolower($type->class()->getSimpleName()));
-    }
-    
-    self::recurse($instance, $type, $tree->root(), []);
-    return $tree->getSource(INDENT_DEFAULT);
-  }
- 
   /**
    * Marshal an object to xml
    *

--- a/src/main/php/xml/meta/Unmarshaller.class.php
+++ b/src/main/php/xml/meta/Unmarshaller.class.php
@@ -9,15 +9,8 @@ use xml\{XMLFormatException, XPath, Xmlmapping, Xmlns};
 /**
  * Creates objects from XML by using annotations.
  *
- * Example:
- * ```php
- * // [...load $xml from a file or a stream...]
- *
- * $transmission= Unmarshaller::unmarshal($xml, 'com.1and1.qf.xml.types.TransmissionType');
- * ```
- *
- * @test  xp://xml.unittest.UnmarshallerTest
  * @ext   dom
+ * @test  xp://xml.unittest.UnmarshallerTest
  * @see   http://castor.org/xml-mapping.html
  */
 class Unmarshaller {
@@ -158,30 +151,6 @@ class Unmarshaller {
     }
 
     return $instance;
-  }
-
-  /**
-   * Unmarshal XML to an object
-   *
-   * @param   string xml
-   * @param   string classname
-   * @return  object
-   * @throws  lang.ClassNotFoundException
-   * @throws  xml.XMLFormatException
-   * @deprecated  Use unmarshalFrom() instead
-   */
-  public static function unmarshal($xml, $classname) {
-    libxml_clear_errors();
-    $doc= new DOMDocument();
-    $source= '(string)';
-    if ('' === (string)$xml) {    // Handle empty string, raise XML_IO_NO_INPUT
-      throw new XMLFormatException('Empty string supplied as input', 1547, $source, 0, 0);
-    }
-    if (!$doc->loadXML($xml)) {
-      $e= libxml_get_last_error();
-      throw new XMLFormatException(trim($e->message), $e->code, $source, $e->line, $e->column);
-    }
-    return self::recurse(new XPath($doc), $doc->documentElement, Reflection::type($classname), []);
   }
 
   /**

--- a/src/test/php/xml/unittest/MarshallerTest.class.php
+++ b/src/test/php/xml/unittest/MarshallerTest.class.php
@@ -139,24 +139,6 @@ class MarshallerTest {
   }
 
   #[Test]
-  public function deprecatedUsage() {
-    $dialog= new DialogType();
-    Assert::equals(
-      Marshaller::marshal($dialog),
-      $this->fixture->marshalTo(new Node('dialogtype'), $dialog)->getSource(INDENT_DEFAULT)
-    );
-  }
-
-  #[Test]
-  public function deprecatedUsageWithNamespace() {
-    $app= new ApplicationType();
-    Assert::equals(
-      Marshaller::marshal($app),
-      $this->fixture->marshalTo(new Node('ApplicationType'), $app)->getSource(INDENT_DEFAULT)
-    );
-  }
-
-  #[Test]
   public function inject() {
     $window= (new WindowType())->withOwnerWindow(1);
     $this->assertMarshalled(

--- a/src/test/php/xml/unittest/UnmarshallerTest.class.php
+++ b/src/test/php/xml/unittest/UnmarshallerTest.class.php
@@ -124,28 +124,10 @@ class UnmarshallerTest {
     );
   }
 
-  #[Test]
-  public function deprecatedUsage() {
-    $xml= '<dialogtype id="file.open"/>';
-    $type= 'xml.unittest.DialogType';
-    Assert::equals(
-      Unmarshaller::unmarshal($xml, $type),
-      $this->fixture->unmarshalFrom(new StreamInputSource(new MemoryInputStream($xml)), $type)
-    );
-  }
-
   #[Test, Expect(XMLFormatException::class)]
   public function malformedString() {
-    Unmarshaller::unmarshal(
-      '<not-valid-xml', 
-      'xml.unittest.DialogType'
-    );
-  }
-
-  #[Test, Expect(XMLFormatException::class)]
-  public function emptyString() {
-    Unmarshaller::unmarshal(
-      '', 
+    $this->fixture->unmarshalFrom(
+      new StreamInputSource(new MemoryInputStream('<not-valid-xml'), 'memory'), 
       'xml.unittest.DialogType'
     );
   }


### PR DESCRIPTION
* [x] ~~`$xml= Marshaller::marshal($transmission);`~~
* [x] ~~`$transmission= Unmarshaller::unmarshal($xml, 'org.example.types.TransmissionType');`~~